### PR TITLE
Fix the bug that raises an AJAX failure even though HTTP 201 is received

### DIFF
--- a/appcell-resources/js/common.js
+++ b/appcell-resources/js/common.js
@@ -930,7 +930,6 @@ cm.retrieveCollectionAPIResponse = function(json) {
     type: "PUT",
     url: cm.user.cellUrl + '__/profile.json',
     data: JSON.stringify(json),
-    dataType: 'json',
     headers: {'Accept':'application/json',
               'Authorization':'Bearer ' + cm.user.access_token}
   }).done(function(data) {


### PR DESCRIPTION
When creating a profile, a failure message is displayed even though the profile is created successfully.
Updating an existing profile does not have any problem.

Box level API (register WebDAV information) actually return response with empty content.
The default dataType should be used instead of "json" to prevent the JSON parsing routine when HTTP 201 is received.