### PR TITLE
IE support

### DIFF
--- a/appcell-resources/css/login.css
+++ b/appcell-resources/css/login.css
@@ -30,6 +30,14 @@ h1{
     border-radius: 20px;
     color: #333333;
 }
+
+/*
+ * IE hack for line-height
+ */
+.login-form-controls input[type=text], .login-form-controls input[type=password] {
+    height: 40px !important;
+}
+
 .login-form-controls input:focus {
     outline: none;
     border: none;

--- a/appcell-resources/js/utils.js
+++ b/appcell-resources/js/utils.js
@@ -1,6 +1,6 @@
 var ut = {};
 
-ut.cellUrlWithEndingSlash = function(tempUrl, raiseError=false) {
+ut.cellUrlWithEndingSlash = function(tempUrl, raiseError) {
     var i = tempUrl.indexOf("/", 8); // search after "http://" or "https://"
 
     if (raiseError && i == -1) {


### PR DESCRIPTION
1. Remove default argument since ES6 is not supported yet
2. A hack for CSS line-height

Closes #62 